### PR TITLE
I linked the available roadmaps to their directed paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Here is the list of available roadmaps with more being actively worked upon.
 
 - [Frontend Roadmap](https://github.com/BuildersChain/Developers-Roadmap/tree/main/Frontend-Developer)
 - [Backend Roadmap](https://github.com/BuildersChain/Developers-Roadmap/tree/main/Backend-Developer)
-- [DevOps Roadmap]()
+- [DevOps Roadmap](https://github.com/BuildersChain/Developers-Roadmap/tree/main/DevOps-Roadmap)
 - [Computer Science Roadmap]()
 - [QA Roadmap]()
 - [Software Architect Roadmap]()
@@ -54,7 +54,7 @@ Here is the list of available roadmaps with more being actively worked upon.
 - [Spring Boot Roadmap]()
 - [Design System Roadmap]()
 - [DBA Roadmap]()
-- [Blockchain Roadmap]()
+- [Blockchain Roadmap](https://github.com/BuildersChain/Developers-Roadmap/tree/main/WEB3-Developer)
 - [ASP.NET Core Roadmap]()
 - [System Design Roadmap]()
 - [Kubernetes Roadmap]()

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Welcome to the Developer Roadmap! This guide is designed to help aspiring develo
 Here is the list of available roadmaps with more being actively worked upon.
 
 - [Frontend Roadmap](https://github.com/BuildersChain/Developers-Roadmap/tree/main/Frontend-Developer)
-- [Backend Roadmap]()
+- [Backend Roadmap](https://github.com/BuildersChain/Developers-Roadmap/tree/main/Backend-Developer)
 - [DevOps Roadmap]()
 - [Computer Science Roadmap]()
 - [QA Roadmap]()


### PR DESCRIPTION
I worked on issue #23 by linking the available roadmaps to their directed paths. 

I can create the other folders for all the roadmaps that I have not linked, can I create an issue for that and work it?